### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/Firefund/firefund-cli.png?label=ready&title=Ready)](https://waffle.io/Firefund/firefund-cli)
 # firefund-cli
 [![Build Status](https://travis-ci.org/Firefund/firefund-cli.svg?branch=master)](https://travis-ci.org/Firefund/firefund-cli)
 [![Coverage Status](https://coveralls.io/repos/Firefund/firefund-cli/badge.svg?branch=master&service=github)](https://coveralls.io/github/Firefund/firefund-cli?branch=master)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/Firefund/firefund-cli

This was requested by a real person (user dotnetCarpenter) on waffle.io, we're not trying to spam you.
